### PR TITLE
chore: update to Go v1.23, update golangci-lint to v1.60.1

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-07-12T18:16:33.525633323Z",
-  "version": "1.2.19",
+  "generated_at": "2024-08-14T07:18:53.460445762Z",
+  "version": "1.2.20",
   "files": [
     {
       "path": ".editorconfig"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -49,7 +49,7 @@ jobs:
         id: golang
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.22
+          go-version: ^1.23
           check-latest: true
 
       - name: Run generate

--- a/.github/workflows/go-binaries.yml
+++ b/.github/workflows/go-binaries.yml
@@ -28,7 +28,7 @@ jobs:
         id: golang
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.22
+          go-version: ^1.23
           check-latest: true
 
       - name: Run generate

--- a/.github/workflows/go-lint-test.yml
+++ b/.github/workflows/go-lint-test.yml
@@ -26,14 +26,14 @@ jobs:
         id: golang
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.22
+          go-version: ^1.23
           check-latest: true
 
       - name: install golangci
         uses: giantswarm/install-binary-action@v3.0.0
         with:
           binary: "golangci-lint"
-          version: "1.59.1"
+          version: "1.60.1"
           download_url: "https://github.com/golangci/golangci-lint/releases/download/v${version}/golangci-lint-${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,13 +2,13 @@
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
   # use the fixed version to not introduce new linters unexpectedly
-  golangci-lint-version: 1.59.1
+  golangci-lint-version: 1.60.1
 
 run:
   # golang-ci lint runtime timeout
   deadline: 5m
   # latest supported Go version
-  go: '1.22'
+  go: '1.23'
   # see: https://golangci-lint.run/usage/configuration/
   modules-download-mode: readonly
   # include test files or not.


### PR DESCRIPTION
chore: update to Go v1.23, update golangci-lint to v1.60.1